### PR TITLE
fix(automation): persist repository-owned scheduled task bindings

### DIFF
--- a/.newchobo/harness/README.md
+++ b/.newchobo/harness/README.md
@@ -1,0 +1,18 @@
+# `.newchobo/harness`
+
+This directory is the repository-local metadata and bootstrap namespace owned by **NewChoBo Harness**.
+
+The `.newchobo/` prefix identifies NewChoBo-owned repository tooling metadata. It does **not** mean the contents are private. In this public repository, every file under `.newchobo/harness/` must be intentionally public-safe.
+
+## Canonical ownership
+
+- shared automation behavior is defined by canonical resources under `standard/`;
+- this directory contains only thin repository/runtime projections over those resources;
+- physical scheduler configuration may point here, but scheduler text is not a second policy store;
+- private consumer evidence, credentials, private runtime state, private identifiers, and consumer-specific policy remain at their authorized private source and must not be copied here.
+
+## Required repository bootstrap
+
+`scheduled-task-bindings.md` is the repository-owned bootstrap source for the standard Harness Scheduled Task roles. Its presence and section contract are repository invariants and are covered by validation tests.
+
+Removing or moving it is a material automation-contract change. A cleanup, migration, or recursive-improvement run must not delete or reconstruct it implicitly. Such a change requires an explicit reviewed candidate that updates the binding path, repository documentation, validation, and physical scheduler pointers together.

--- a/.newchobo/harness/scheduled-task-bindings.md
+++ b/.newchobo/harness/scheduled-task-bindings.md
@@ -1,0 +1,86 @@
+# ChatGPT Scheduled Task Bindings
+
+Status: public repository-owned Harness runtime bootstrap source
+
+This file is a thin projection over canonical Harness Standard resources. It does not own detailed automation policy.
+
+## Common bootstrap
+
+Every binding:
+
+- freezes the current remote `main` exact SHA once at run start;
+- loads `AGENTS.md`, `standard/catalog.yaml`, `protocol/automation-operation`, and the role-specific canonical resources from that same snapshot;
+- restores only current public repository state needed for the selected work;
+- fails closed when this binding or any required canonical source cannot be verified;
+- never reconstructs a missing or moved path from memory, archive history, previous repository generations, old scheduler text, or another consumer;
+- treats every repository/GitHub persistence surface as public;
+- performs source mutations only through the role-appropriate candidate/PR lifecycle;
+- does not change physical task population/cadence or widen authority merely because runtime tooling exposes those controls;
+- permits `NO_ACTION` without persistence noise.
+
+## governor
+
+Load at minimum:
+
+- `standard/roles/governor.md`
+- `standard/protocols/adoption-lifecycle.md`
+- `standard/protocols/automation-operation.md`
+- `standard/checklists/pre-adoption-review.md`
+
+Restore current public candidate/review/adoption state. Integrate only an exact candidate with fresh producer-distinct `REVIEW_PASSED`, satisfied validation, no unresolved material blocker, and applicable authority. Normal integration is merge of the exact reviewed PR. Do not directly author source on `main`.
+
+When release/tag authority has been explicitly delegated, the Governor may create an applicable reviewed release tag only after confirming the exact integrated commit, release version/cohort, required validation, and repository release policy. Tagging is not implied by ordinary adoption authority.
+
+## supervisor
+
+Load at minimum:
+
+- `standard/roles/supervisor.md`
+- `standard/protocols/control-cycle.md`
+- `standard/protocols/deep-audit-and-escalation.md`
+- `standard/protocols/checkpoint-handoff.md`
+- `standard/protocols/automation-operation.md`
+
+Restore current public Issues/PRs/candidates/reviews/blockers, active topic branches, and material continuations. Reconcile ownership/dependencies/duplicate work, route the highest-value bounded control action, and ensure material child failure/recovery/blocker state remains visible upward. Do not implement source or write source files directly to `main`.
+
+When a non-main branch is not actively owned but contains unfinished material work, route continuation to completion/review/merge before cleanup. Delete a branch only after verifying that its material delta is integrated, superseded, or intentionally abandoned under current authority.
+
+## worker
+
+Load at minimum:
+
+- `standard/roles/worker.md`
+- `standard/protocols/change-safety.md`
+- `standard/protocols/automation-operation.md`
+- `standard/checklists/agent-self-check.md`
+
+Restore one current decision-ready public work item. Implement on a topic/candidate branch, run applicable validation, freeze the exact candidate, and open/update a PR for producer-distinct review. Never write source files directly to `main`, self-review formally, or self-adopt.
+
+## independent-reviewer
+
+Load at minimum:
+
+- `standard/roles/independent-reviewer.md`
+- `standard/protocols/adoption-lifecycle.md`
+- `standard/protocols/automation-operation.md`
+- `standard/checklists/pre-adoption-review.md`
+
+Select one eligible frozen exact candidate, inspect its actual diff/effective resources and validation evidence, and persist a public-safe verdict/handoff. Do not modify candidate source, sync/rebase it, or write source files directly to `main`.
+
+## Physical task bootstrap
+
+A physical task must contain both the pointer values **and** the minimal executable bootstrap instruction required to obtain this file safely. The v0.x scheduler prompt cannot assume that instructions inside this file are already known before the file is loaded.
+
+Minimum shape:
+
+```text
+repository: NewChoBo/harness
+control_ref: refs/heads/main
+prompt_source: .newchobo/harness/scheduled-task-bindings.md#<binding-key>
+
+Freeze control_ref to one exact SHA before reading prompt_source. Load prompt_source and every canonical resource it requires from that same frozen snapshot, then execute the selected binding. If prompt_source or a required resource is absent, moved, unreadable, or unverifiable, fail closed; do not reconstruct it from memory, archives, previous repository generations, old task text, or another consumer.
+```
+
+Runtime-only values may be appended when genuinely necessary, but detailed automation policy stays in repository Standard/resources rather than becoming a second scheduler policy store.
+
+Future policy edits change canonical repository resources first, then reconcile existing physical tasks in place. Moving or deleting this file is a material automation-contract migration and must update validation and physical pointers in the same reviewed change.

--- a/docs/decisions/0013-repository-owned-scheduled-task-bindings.md
+++ b/docs/decisions/0013-repository-owned-scheduled-task-bindings.md
@@ -1,0 +1,26 @@
+# 0013 — Repository-owned Scheduled Task bindings are durable product metadata
+
+Status: proposed
+
+## Context
+
+Physical Scheduled Task prompts previously carried too much policy and could drift from repository truth. During public-repository migration, a missing or moved binding was also misread as something to reconstruct or clean up, creating repeated add/remove churn around automation files.
+
+The public Harness needs a stable repository-owned bootstrap path while keeping detailed behavior in canonical Standard resources.
+
+## Decision
+
+- `.newchobo/harness/` is the public repository-local metadata namespace owned by NewChoBo Harness;
+- `.newchobo/harness/scheduled-task-bindings.md` is the required thin bootstrap projection for standard Scheduled Task roles;
+- `protocol/automation-operation` owns reusable scheduled-execution, branch lifecycle, trusted-ref, recovery/reporting, and binding-migration semantics;
+- physical scheduler prompts contain only repository/ref/prompt-source pointers plus genuinely runtime-only values;
+- deleting or moving the binding path is a material migration, not routine cleanup;
+- validation must fail if the required binding or role sections disappear;
+- missing/moved control sources fail closed and are never reconstructed from memory, archives, previous repository generations, or old scheduler text;
+- private consumer/domain state remains outside the public repository.
+
+## Consequences
+
+The binding path becomes stable enough for scheduler pointers while detailed automation rules can evolve through Standard resources without prompt duplication. Cleanup automation gains an explicit ownership signal and regression tests prevent accidental removal from being accepted as a valid candidate.
+
+The cost is that a future intentional path migration must update repository docs/tests, canonical protocol references, and physical scheduler pointers in one governed change.

--- a/standard/catalog.yaml
+++ b/standard/catalog.yaml
@@ -70,6 +70,11 @@ spec:
       provenance:
         - docs/decisions/0002-supervisor-control-first.md
         - docs/decisions/0004-hierarchical-approval-enables-self-evolution.md
+    - id: protocol/automation-operation
+      kind: Protocol
+      path: standard/protocols/automation-operation.md
+      representation: narrative
+      provenance: docs/decisions/0013-repository-owned-scheduled-task-bindings.md
     - id: protocol/checkpoint-handoff
       kind: Protocol
       path: standard/protocols/checkpoint-handoff.md

--- a/standard/protocols/automation-operation.md
+++ b/standard/protocols/automation-operation.md
@@ -1,0 +1,105 @@
+# Scheduled Automation Operation
+
+Resource ID: `protocol/automation-operation`
+
+This protocol defines the reusable control contract for recurring or scheduled Harness execution. Scheduler-specific cadence and physical task population remain runtime configuration, not canonical Harness policy.
+
+## Repository-owned bootstrap
+
+A physical Scheduled Task is a thin runtime binding. A repository may project its standard role bindings at a repository-owned path such as:
+
+```text
+.newchobo/harness/scheduled-task-bindings.md
+```
+
+The concrete path is repository-local configuration. Once adopted as a repository binding source, it is required metadata rather than disposable generated output; removing, relocating, or replacing it is a material automation-contract migration.
+
+At run start:
+
+1. resolve the configured repository and trusted control ref;
+2. freeze the exact control revision once;
+3. load the repository-owned binding and every required canonical resource from that same snapshot;
+4. restore only current durable state needed for the selected work;
+5. verify ownership, authority, candidate/review identity, dependencies, and public-safety constraints before mutation.
+
+If the configured binding or required canonical source is missing, unreadable, moved without a compatible migration, or cannot be verified, terminate as `CONTROL_SOURCE_MISSING` or `CONTROL_SOURCE_UNVERIFIED`.
+
+**Missing control source is never permission to reconstruct, restore, delete-and-recreate, or replace it from conversational memory, archive history, an earlier repository generation, old Scheduled Task text, or another consumer.**
+
+## Source-layout and cleanup safety
+
+A cleanup, migration, recursive-improvement, or repository-normalization run must distinguish:
+
+- required product/source/metadata contracts;
+- generated or disposable artifacts;
+- stale branches/candidates;
+- private/consumer-local material that does not belong in a public repository.
+
+A dot-prefixed vendor directory is not inherently private or disposable. Repository-owned metadata must be classified from current repository truth and its canonical owner, not from naming heuristics alone.
+
+Before deleting or moving a required path, the acting role must identify the current canonical owner, dependent physical/runtime pointers, validation coverage, migration/rollback plan, and exact reviewed replacement. Unknown ownership or dependency state fails closed.
+
+## Trusted-ref mutation discipline
+
+The repository binding defines one trusted integration ref (for example `main`, `master`, `trunk`, or a governed release/integration branch). Shared Harness semantics refer to that configured trusted ref rather than assuming a branch name.
+
+- **Worker / Producer** — performs source changes on a topic/candidate branch distinct from the configured trusted integration ref and opens or updates a PR. Never directly authors source on the trusted ref.
+- **Supervisor** — restores state, reconciles ownership/dependencies/branches, and routes work. It does not implement source or directly author the trusted ref.
+- **Independent Reviewer** — reviews the frozen exact candidate and persists a verdict. It does not modify, rebase, or sync the candidate.
+- **Governor / Adopter** — integrates only an exact candidate with a fresh valid producer-distinct review and satisfied gates, normally by merging the reviewed PR into the configured trusted ref. It does not bypass review by directly editing that ref.
+
+An emergency direct trusted-ref remediation is outside ordinary automation and requires explicit applicable administrator authority plus proportional verification.
+
+## Branch lifecycle
+
+Automation performs material source changes on candidate/topic branches distinct from the configured trusted integration ref.
+
+A candidate/topic branch may be removed only after verifying one of:
+
+- its material delta is integrated into the configured trusted ref;
+- it is fully superseded by an identified integrated/reviewed replacement;
+- it is intentionally abandoned under current authority with no unique required delta.
+
+Never classify a branch as cleanup-eligible merely because its name differs from `main`; first resolve whether it is the configured trusted integration ref, a protected release/integration ref, or an active governed work ref.
+
+If a branch contains unfinished material work and is not actively owned, the Supervisor routes continuation to completion, validation, review, and integration rather than silently abandoning or deleting it.
+
+After successful integration, remove the merged candidate branch when repository capabilities permit and verify ref absence before reporting cleanup complete.
+
+## Failure, self-recovery, and upward reporting
+
+Self-recovery is allowed within current authority, but silent failure is not.
+
+```text
+FAILURE_OBSERVED
+-> report material failure state to organizational/control owner
+-> bounded self-recovery when safe and authorized
+-> RECOVERED | DEGRADED | BLOCKED
+-> unresolved BLOCKED state escalates upward
+```
+
+A GitHub Issue is durable work/evidence, not proof that organizational reporting occurred. The highest applicable control owner re-evaluates unresolved failures and asks the administrator/user only when administrator authority, reserved judgment, credentials/access, or another genuinely human-only action is required.
+
+Repeated equivalent failures are deduplicated by stable target/failure/blocker identity rather than creating per-run Issue/comment noise.
+
+## Release tagging
+
+Release/tag creation is separate from ordinary implementation/adoption authority.
+
+When a higher management/Governor role has explicit standing release-tag authority, it may create a release tag only after verifying:
+
+- the exact integrated trusted-ref commit;
+- package/release version consistency;
+- required CI/release checks and current release policy;
+- no unresolved material review/blocker;
+- expected tag-triggered release behavior.
+
+Tagging must not be used to bypass candidate review, and a failed release workflow remains a material failure requiring diagnosis/reporting.
+
+## Scheduler self-modification boundary
+
+Ordinary role execution does not create, delete, enable, disable, or change cadence/population of physical Scheduled Tasks merely because runtime tooling exposes those controls. Task-topology changes require explicit management authority.
+
+## Completion
+
+A material automation run ends with enough durable public-safe state for the next owner to know the exact control/candidate identity, branch/PR state, verified outcome, validation/review state, unresolved blocker, recovery/escalation state, and next owner/action. `NO_ACTION` is valid when no material current work exists.

--- a/test/scheduled-task-bindings.test.ts
+++ b/test/scheduled-task-bindings.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const bindingPath = '.newchobo/harness/scheduled-task-bindings.md';
+
+describe('repository-owned Scheduled Task bindings', () => {
+  const binding = readFileSync(bindingPath, 'utf8');
+
+  it('keeps the required public Harness binding file present', () => {
+    expect(binding.length).toBeGreaterThan(0);
+  });
+
+  it.each(['governor', 'supervisor', 'worker', 'independent-reviewer'])(
+    'defines the %s binding',
+    (role) => {
+      expect(binding).toContain(`## ${role}`);
+    },
+  );
+
+  it('points physical tasks at the stable repository path', () => {
+    expect(binding).toContain(
+      'prompt_source: .newchobo/harness/scheduled-task-bindings.md#<binding-key>',
+    );
+  });
+
+  it('fails closed instead of treating missing control as repair instructions', () => {
+    expect(binding).toContain('fails closed');
+    expect(binding).toContain('never reconstructs');
+  });
+
+  it('does not reintroduce the superseded private-control path', () => {
+    expect(binding).not.toContain('.newchobo/automation/chatgpt-scheduled-task-bindings.md');
+  });
+});


### PR DESCRIPTION
## Goal

Stop `.newchobo/harness/scheduled-task-bindings.md` from being repeatedly removed/reconstructed by making it an explicit durable public Harness repository contract rather than an uncataloged hidden file.

## Root cause

Current `main` has no `.newchobo/harness/scheduled-task-bindings.md`, no canonical scheduled-automation protocol, and no validation that this repository-owned bootstrap must exist. The earlier definition lived only on a stale/unmerged candidate, so an agent restoring current `main` could reasonably misclassify the dot-prefixed path as obsolete/private-control residue.

## Changes

- add `.newchobo/harness/README.md` declaring the public product metadata namespace;
- add the stable repository-owned `scheduled-task-bindings.md` for Governor/Supervisor/Worker/Independent Reviewer;
- add canonical `protocol/automation-operation` covering fail-closed source restoration, topic-branch/PR mutation, branch continuation/cleanup, upward failure reporting, and delegated release tagging;
- record the ownership decision in ADR 0013;
- add a regression test that fails when the binding file/role sections/stable pointer disappear or the superseded `.newchobo/automation/...` path is reintroduced.

## Safety

This candidate contains no consumer-private identifiers, private evidence, credentials, or private runtime state. `.newchobo/harness/**` is explicitly public-safe product metadata.

## Done criteria

- exact-head CI passes;
- producer-distinct review finds no material blocker;
- merge to `main`;
- verify the binding exists on `main` after merge;
- physical Scheduled Tasks may then safely point to `.newchobo/harness/scheduled-task-bindings.md#<role>`;
- future cleanup/removal of the path requires an explicit reviewed migration rather than implicit deletion.