### PR TITLE
feat(automation): make agents own relevant Issue lifecycle

### DIFF
--- a/.newchobo/harness/scheduled-task-bindings.md
+++ b/.newchobo/harness/scheduled-task-bindings.md
@@ -10,7 +10,11 @@ Every binding:
 
 - freezes the current remote `main` exact SHA once at run start;
 - loads `AGENTS.md`, `standard/catalog.yaml`, `protocol/automation-operation`, and the role-specific canonical resources from that same snapshot;
-- restores only current public repository state needed for the selected work;
+- inspects current open Issues/PRs relevant to the role's scope before selecting new work;
+- restores explicitly routed/assigned owned Issues and their branch/PR/review/CI/dependency state before creating duplicate work;
+- continues valid unfinished owned work and, after verifying the Issue's actual acceptance/done criteria plus any required linked source-change review/integration gate, closes the owned Issue when capability and authority permit;
+- keeps a source-change Issue open while its required linked PR review/integration is unresolved unless the Issue explicitly defines a durable implementation-only handoff as completion;
+- never closes another role's Issue merely because it is related; route/handoff foreign ownership instead;
 - fails closed when this binding or any required canonical source cannot be verified;
 - never reconstructs a missing or moved path from memory, archive history, previous repository generations, old scheduler text, or another consumer;
 - treats every repository/GitHub persistence surface as public;
@@ -27,7 +31,9 @@ Load at minimum:
 - `standard/protocols/automation-operation.md`
 - `standard/checklists/pre-adoption-review.md`
 
-Restore current public candidate/review/adoption state. Integrate only an exact candidate with fresh producer-distinct `REVIEW_PASSED`, satisfied validation, no unresolved material blocker, and applicable authority. Normal integration is merge of the exact reviewed PR. Do not directly author source on `main`.
+Restore current public adoption-owned Issues plus candidate/review/adoption state. Integrate only an exact candidate with fresh producer-distinct `REVIEW_PASSED`, satisfied validation, no unresolved material blocker, and applicable authority. Normal integration is merge of the exact reviewed PR. Do not directly author source on `main`.
+
+If an adoption/release Issue is owned by the Governor, reconcile it against the resulting trusted-ref/release evidence and close it only when its acceptance criteria are actually satisfied.
 
 When release/tag authority has been explicitly delegated, the Governor may create an applicable reviewed release tag only after confirming the exact integrated commit, release version/cohort, required validation, and repository release policy. Tagging is not implied by ordinary adoption authority.
 
@@ -43,6 +49,8 @@ Load at minimum:
 
 Restore current public Issues/PRs/candidates/reviews/blockers, active topic branches, and material continuations. Reconcile ownership/dependencies/duplicate work, route the highest-value bounded control action, and ensure material child failure/recovery/blocker state remains visible upward. Do not implement source or write source files directly to `main`.
 
+The Supervisor closes only Issues it actually owns, such as resolved coordination/topology/ownership work. It must not close a Worker/Reviewer/Governor-owned Issue on that role's behalf merely because the downstream action finished; it verifies/reroutes stale ownership instead.
+
 When a non-main branch is not actively owned but contains unfinished material work, route continuation to completion/review/merge before cleanup. Delete a branch only after verifying that its material delta is integrated, superseded, or intentionally abandoned under current authority.
 
 ## worker
@@ -54,7 +62,9 @@ Load at minimum:
 - `standard/protocols/automation-operation.md`
 - `standard/checklists/agent-self-check.md`
 
-Restore one current decision-ready public work item. Implement on a topic/candidate branch, run applicable validation, freeze the exact candidate, and open/update a PR for producer-distinct review. Never write source files directly to `main`, self-review formally, or self-adopt.
+Before selecting new implementation, inspect relevant open implementation Issues and restore the current owned work item/branch/PR state. Implement one current decision-ready owned work item on a topic/candidate branch, run applicable validation, freeze the exact candidate, and open/update a PR for producer-distinct review. Never write source files directly to `main`, self-review formally, or self-adopt.
+
+When the Worker-owned Issue's acceptance criteria or repository lifecycle require downstream review/integration, leave it open with the exact handoff state until those gates are met. When its criteria and required linked integration state are fully verified within current authority, close it in the same run rather than leaving completed implementation Issues stale.
 
 ## independent-reviewer
 
@@ -65,7 +75,9 @@ Load at minimum:
 - `standard/protocols/automation-operation.md`
 - `standard/checklists/pre-adoption-review.md`
 
-Select one eligible frozen exact candidate, inspect its actual diff/effective resources and validation evidence, and persist a public-safe verdict/handoff. Do not modify candidate source, sync/rebase it, or write source files directly to `main`.
+Inspect relevant open review Issues/requests and select one eligible frozen exact candidate. Inspect its actual diff/effective resources and validation evidence, then persist a public-safe verdict/handoff. Do not modify candidate source, sync/rebase it, or write source files directly to `main`.
+
+If a review Issue/request is owned by the Reviewer, close that review work item after the exact candidate verdict and required review evidence are durably persisted. The Reviewer must not close the producer's implementation Issue; return or route that Issue to its owning role for final lifecycle reconciliation.
 
 ## Physical task bootstrap
 

--- a/standard/protocols/automation-operation.md
+++ b/standard/protocols/automation-operation.md
@@ -19,12 +19,33 @@ At run start:
 1. resolve the configured repository and trusted control ref;
 2. freeze the exact control revision once;
 3. load the repository-owned binding and every required canonical resource from that same snapshot;
-4. restore only current durable state needed for the selected work;
-5. verify ownership, authority, candidate/review identity, dependencies, and public-safety constraints before mutation.
+4. restore current role-relevant open Issues/PRs plus only the durable state needed for the selected work;
+5. reconcile existing ownership, candidate/branch/review/dependency/blocker state before creating new work;
+6. verify authority and public-safety constraints before mutation.
 
 If the configured binding or required canonical source is missing, unreadable, moved without a compatible migration, or cannot be verified, terminate as `CONTROL_SOURCE_MISSING` or `CONTROL_SOURCE_UNVERIFIED`.
 
 **Missing control source is never permission to reconstruct, restore, delete-and-recreate, or replace it from conversational memory, archive history, an earlier repository generation, old Scheduled Task text, or another consumer.**
+
+## Role-owned Issue lifecycle
+
+Every recurring role is responsible for the lifecycle of Issues that are genuinely inside that role's current scope/ownership. This is scoped ticket awareness, not a requirement for every role to sweep the entire repository backlog.
+
+At each run, before selecting new work:
+
+1. inspect current open Issues and PRs relevant to the role's scope, including explicitly assigned/routed work and durable handoffs;
+2. restore any existing owned Issue before creating a duplicate work item;
+3. reconcile the Issue against current branch/PR/review/CI/integration/effect evidence;
+4. continue or recover owned unfinished work when it remains valid and actionable;
+5. when the Issue's current done/acceptance criteria are verified **and every required linked source-change review/integration gate for that Issue is satisfied**, persist only useful completion evidence and close the owned Issue in the same run when capability and authority permit;
+6. when an owned Issue is duplicate, superseded, or no longer required, close it only after identifying the current replacement/evidence and when that disposition is within role authority;
+7. if the Issue belongs to another role/owner, do not close or silently take it over—route/handoff it to the proper owner and preserve the dependency/blocker relation.
+
+For a source-change Issue, an open linked PR normally means the Issue remains open while required review/integration is unresolved. A repository may define an explicit implementation-only Issue whose done state is a durable handoff to another owned work item, but that handoff must be explicit; do not infer it merely because a producer finished coding.
+
+A role must not leave a verified-complete Issue open merely because implementation or merge finished. Conversely, a merged PR or a completion report alone is not enough to close an Issue unless its actual acceptance criteria are satisfied.
+
+Issue comments are delta/evidence surfaces, not mandatory heartbeat logs. Do not emit unchanged per-run status comments. Closing an Issue is a lifecycle action, not a substitute for required upward failure reporting or post-adoption effect validation.
 
 ## Source-layout and cleanup safety
 
@@ -98,8 +119,8 @@ Tagging must not be used to bypass candidate review, and a failed release workfl
 
 ## Scheduler self-modification boundary
 
-Ordinary role execution does not create, delete, enable, disable, or change cadence/population of physical Scheduled Tasks merely because runtime tooling exposes those controls. Task-topology changes require explicit management authority.
+Ordinary role execution does not create, delete, enable, disable, or change cadence/population of physical Scheduled Tasks merely because the runtime exposes those controls. Task-topology changes require explicit management authority.
 
 ## Completion
 
-A material automation run ends with enough durable public-safe state for the next owner to know the exact control/candidate identity, branch/PR state, verified outcome, validation/review state, unresolved blocker, recovery/escalation state, and next owner/action. `NO_ACTION` is valid when no material current work exists.
+A material automation run ends with enough durable public-safe state for the next owner to know the exact control/candidate identity, owned Issue/PR state, branch/review/integration state, verified outcome, validation state, unresolved blocker, recovery/escalation state, and next owner/action. `NO_ACTION` is valid when no material current work exists.

--- a/test/scheduled-task-bindings.test.ts
+++ b/test/scheduled-task-bindings.test.ts
@@ -2,31 +2,61 @@ import { readFileSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
 
-const bindingPath = '.newchobo/harness/scheduled-task-bindings.md';
+const binding = readFileSync('.newchobo/harness/scheduled-task-bindings.md', 'utf8');
+const protocol = readFileSync('standard/protocols/automation-operation.md', 'utf8');
+
+function expectContains(source: string, fragments: string[]) {
+  for (const fragment of fragments) {
+    expect(source).toContain(fragment);
+  }
+}
 
 describe('repository-owned Scheduled Task bindings', () => {
-  const binding = readFileSync(bindingPath, 'utf8');
-
   it('keeps the required public Harness binding file present', () => {
     expect(binding.length).toBeGreaterThan(0);
   });
 
-  it.each(['governor', 'supervisor', 'worker', 'independent-reviewer'])(
-    'defines the %s binding',
-    (role) => {
-      expect(binding).toContain(`## ${role}`);
-    },
-  );
-
-  it('points physical tasks at the stable repository path', () => {
-    expect(binding).toContain(
-      'prompt_source: .newchobo/harness/scheduled-task-bindings.md#<binding-key>',
-    );
+  it('defines the standard role bindings', () => {
+    expectContains(binding, [
+      '## governor',
+      '## supervisor',
+      '## worker',
+      '## independent-reviewer',
+    ]);
   });
 
-  it('fails closed instead of treating missing control as repair instructions', () => {
-    expect(binding).toContain('fails closed');
-    expect(binding).toContain('never reconstructs');
+  it('keeps the stable physical task pointer', () => {
+    expectContains(binding, [
+      'prompt_source: .newchobo/harness/scheduled-task-bindings.md#<binding-key>',
+    ]);
+  });
+
+  it('guards role-owned Issue lifecycle semantics', () => {
+    expectContains(binding, [
+      'open Issues/PRs relevant to the role',
+      'closes the owned Issue',
+      'keeps a source-change Issue open',
+      'route/handoff foreign ownership',
+      "The Reviewer must not close the producer's implementation Issue",
+      'return or route that Issue to its owning role',
+    ]);
+  });
+
+  it('guards canonical Issue lifecycle semantics', () => {
+    expectContains(protocol, [
+      'Every recurring role is responsible',
+      'restore any existing owned Issue',
+      'linked source-change review/integration gate',
+      'an open linked PR normally means the Issue remains open',
+      'if the Issue belongs to another role/owner, do not close',
+      'a merged PR or a completion report alone is not enough',
+      'required upward failure reporting',
+      'post-adoption effect validation',
+    ]);
+  });
+
+  it('fails closed when control sources are unavailable', () => {
+    expectContains(binding, ['fails closed', 'never reconstructs']);
   });
 
   it('does not reintroduce the superseded private-control path', () => {


### PR DESCRIPTION
## Goal

Make every recurring Harness role inspect the GitHub Issues/PRs relevant to its own scope, resume existing owned work before creating duplicates, and close its own Issue once the Issue's actual acceptance criteria are verified.

## Semantics

- scoped ticket awareness for every role; global backlog triage remains Supervisor-oriented;
- restore explicitly routed/assigned owned Issues plus branch/PR/review/CI/dependency state before new work;
- do not leave a verified-complete owned Issue open;
- do not close another role's Issue merely because related downstream work finished;
- merged PR/completion report alone is not sufficient if Issue acceptance criteria remain unmet;
- duplicate/superseded/no-longer-required owned Issues may be closed only with current replacement/evidence and proper authority;
- Issue comments remain delta/evidence surfaces, not heartbeat logs;
- Issue closure does not replace upward failure reporting or effect validation.

## Files

- `standard/protocols/automation-operation.md`
- `.newchobo/harness/scheduled-task-bindings.md`
- `test/scheduled-task-bindings.test.ts`

## Validation

Exact-head CI plus producer-distinct review required before merge.