### PR TITLE
feat(automation): separate reconciliation from source-mutation budget

### DIFF
--- a/standard/protocols/automation-operation.md
+++ b/standard/protocols/automation-operation.md
@@ -47,25 +47,56 @@ If the configured binding or required canonical source is missing, unreadable, m
 
 **Missing control source is never permission to reconstruct, restore, delete-and-recreate, or replace it from conversational memory, archive history, an earlier repository generation, old Scheduled Task text, another consumer, or a stale branch.**
 
-## One material action
+## Bounded reconciliation and source-mutation budget
 
-Each run selects at most one highest-value material action. `NO_ACTION` is valid. Recurring schedules are not work-generation quotas.
+Recurring execution distinguishes control/lifecycle reconciliation from source mutation.
 
-Restore current Issues, PRs, branches, reviews, checks, release state, continuations, failures, and dependencies before selection. Live state overrides stale checkpoints.
+```text
+bounded control/lifecycle reconciliation
++
+default: at most one logical source-changing work item
+```
+
+The default one-item limit applies to **source mutation**, not to every read-only observation or already-gated lifecycle transition.
+
+A run may inspect a bounded set of currently owned work items to prevent passive waiting from monopolizing recurring execution. Descriptive reconciliation outcomes may include:
+
+- `ACTION_REQUIRED` — the current owner needs an actual source-producing action;
+- `READY_TO_INTEGRATE` — required current gates are satisfied and the applicable authority may integrate/close/clean up;
+- `WAITING_VALIDATION` — external/current validation is still pending;
+- `WAITING_REVIEW` — required independent review is still pending;
+- `WAITING_DEPENDENCY` — a real prerequisite is still pending;
+- `BLOCKED` — action cannot continue without a material capability/authority/failure resolution;
+- `DONE` — actual acceptance/integration conditions are verified.
+
+These are reconciliation descriptions, not a competing global lifecycle state machine.
+
+Rules:
+
+- Passive `WAITING_*` observation does not by itself consume the run's source-mutation budget and should not require an unchanged heartbeat comment.
+- When an item is already fully gated, an authorized role may complete the applicable integration, closure, or cleanup transition in the same run without manufacturing another source-change item.
+- Existing owned `ACTION_REQUIRED` work remains preferred over starting a competing duplicate.
+- If no owned work requires source mutation, a workflow may select another authorized actionable item according to its repository-local priority policy.
+- The shared default remains at most one logical source-changing work item per run unless an explicitly adopted workflow defines a different safe budget.
+- This section does not authorize a full backlog sweep, parallel edits, branch proliferation, self-review, weaker validation, release/publication bypass, or takeover of another owner.
+- `NO_ACTION` remains valid. Recurring schedules are not work-generation quotas.
+
+Live state overrides stale checkpoints.
 
 ## Role-owned Issue lifecycle
 
 Every recurring role is responsible for the lifecycle of Issues that are genuinely inside that role's current scope/ownership. This is scoped ticket awareness, not a requirement for every role to sweep the entire repository backlog.
 
-At each run, before selecting new work:
+At each run, before selecting new source work:
 
 1. inspect current open Issues and PRs relevant to the role's scope, including explicitly assigned/routed work and durable handoffs;
-2. restore any existing owned Issue before creating a duplicate work item;
-3. reconcile the Issue against current branch/PR/review/CI/integration/effect evidence;
+2. restore existing owned Issues before creating duplicate work items;
+3. reconcile them against current branch/PR/review/CI/integration/effect evidence;
 4. continue or recover owned unfinished work when it remains valid and actionable;
-5. when the Issue's current done/acceptance criteria are verified **and every required linked source-change review/integration gate for that Issue is satisfied**, persist only useful completion evidence and close the owned Issue in the same run when capability and authority permit;
-6. when an owned Issue is duplicate, superseded, or no longer required, close it only after identifying the current replacement/evidence and when that disposition is within role authority;
-7. if the Issue belongs to another role/owner, do not close or silently take it over—route/handoff it to the proper owner and preserve the dependency/blocker relation.
+5. do not let passive waiting on one owned item prevent unrelated authorized actionable work when the workflow permits the bounded reconciliation/source-budget model above;
+6. when the Issue's current done/acceptance criteria are verified **and every required linked source-change review/integration gate for that Issue is satisfied**, persist only useful completion evidence and close the owned Issue in the same run when capability and authority permit;
+7. when an owned Issue is duplicate, superseded, or no longer required, close it only after identifying the current replacement/evidence and when that disposition is within role authority;
+8. if the Issue belongs to another role/owner, do not close or silently take it over—route/handoff it to the proper owner and preserve the dependency/blocker relation.
 
 For a source-change Issue, an open linked PR normally means the Issue remains open while required review/integration is unresolved. A repository may define an explicit implementation-only Issue whose done state is a durable handoff to another owned work item, but that handoff must be explicit; do not infer it merely because a producer finished coding.
 

--- a/standard/roles/supervisor.md
+++ b/standard/roles/supervisor.md
@@ -34,6 +34,8 @@ When repository automation or public persistence is material, also resolve and a
 - treat physical scheduler placement as runtime topology rather than logical role identity; preserve required review isolation and authority even when compatible stages share one physical execution;
 - preserve explicit paused/disabled desired state and do not recreate or resume a paused lane without applicable authority or a satisfied declared resume condition;
 - inspect subordinate scheduled-run status/results when material, but verify substantive completion claims against actual repository/runtime evidence before closing, adopting, or rerouting work;
+- distinguish passive reconciliation (`WAITING_VALIDATION`, `WAITING_REVIEW`, `WAITING_DEPENDENCY`) from source work that actually requires a producer mutation; passive waiting should not repeatedly monopolize a recurring execution when unrelated authorized actionable work exists;
+- allow a bounded control/lifecycle sweep to verify several owned items and complete already-gated closure/integration cleanup when current role authority permits, while preserving the workflow's separate source-mutation budget and avoiding a full-backlog sweep;
 - treat runtime task-capacity constraints as execution evidence rather than policy; prefer compatible composition/reuse/lower cadence without weakening validation, authority, or Producer/Independent Reviewer separation;
 - track release readiness and post-adoption effect, and simplify/remove ineffective or duplicate machinery.
 
@@ -45,10 +47,11 @@ When repository automation or public persistence is material, also resolve and a
 - never reconstruct a missing control source from memory, archives, private consumers, or stale task prompts;
 - must not infer approval from proposals/questions/brainstorming;
 - must not suppress a material child failure because recovery was attempted;
-- must not treat a scheduler's `completed` status or a subordinate completion report as independent proof of acceptance, validation, review, integration, release, or effect.
+- must not treat a scheduler's `completed` status or a subordinate completion report as independent proof of acceptance, validation, review, integration, release, or effect;
+- must not interpret bounded reconciliation as authority to sweep/take over every open Issue or to parallelize source mutations that the owning workflow keeps serial.
 
 ## Evidence / completion
 
 A material checkpoint records current control identity, classification, unique owner/routing, branch/PR/candidate/review/check/adoption/release/effect state, material failure/recovery status, scheduler/topology state when relevant, blockers, cleanup obligation, next action, and only genuine upward decisions.
 
-Routine leaf reports are aggregated. Material blockers, failed recovery, reserved human actions, and release/tag decisions remain visible rather than being averaged into an apparent success.
+Routine leaf reports are aggregated. Passive waiting is recorded only when materially useful; unchanged wait-state heartbeat comments are unnecessary. Material blockers, failed recovery, reserved human actions, and release/tag decisions remain visible rather than being averaged into an apparent success.

--- a/test/scheduled-task-bindings.test.ts
+++ b/test/scheduled-task-bindings.test.ts
@@ -45,13 +45,22 @@ describe('repository-owned Scheduled Task bindings', () => {
   it('guards canonical Issue lifecycle semantics', () => {
     expectContains(protocol, [
       'Every recurring role is responsible',
-      'restore any existing owned Issue',
+      'restore existing owned Issues',
       'linked source-change review/integration gate',
       'an open linked PR normally means the Issue remains open',
       'if the Issue belongs to another role/owner, do not close',
       'a merged PR or a completion report alone is not enough',
       'required upward failure reporting',
       'post-adoption effect validation',
+    ]);
+  });
+
+  it('guards reconciliation and source-mutation budget separation', () => {
+    expectContains(protocol, [
+      'Bounded reconciliation and source-mutation budget',
+      'Passive `WAITING_*` observation does not by itself consume',
+      'at most one logical source-changing work item per run',
+      'does not authorize a full backlog sweep',
     ]);
   });
 


### PR DESCRIPTION
Closes #14

## Goal

Generalize a product-neutral recurring-automation throughput rule proven in multiple consumers without importing their business logic, repository names, queue priorities, CI policy or runtime schedule.

## Changes

- replace the ambiguous `one material action` interpretation with bounded control/lifecycle reconciliation plus a default one-logical-item source-mutation budget;
- define descriptive `ACTION_REQUIRED / READY_TO_INTEGRATE / WAITING_* / BLOCKED / DONE` reconciliation outcomes without creating a new lifecycle state machine;
- make passive waiting non-consuming for source-mutation selection;
- permit already-gated integration/closure/cleanup when current authority allows;
- update Supervisor guidance so a waiting item cannot monopolize every recurring run while unrelated authorized actionable work exists;
- update the repository contract test to assert the semantic invariants rather than one obsolete literal phrase.

## Public boundary

No consumer/product/business-domain identifier, priority policy, task cadence, private data, customer logic or repository-specific validation rule is included. Repository-specific selection and integration policy remains consumer-owned.

## Current exact candidate

Rebuilt directly on current `main@45755be1943c9b21a2a651a7decb20051c6dbafc` after Novel PR #16 landed, preserving only the three intended files.

Current head: `9762388b4faee9ce1479d763c4b18a0971625b3c`.

Fresh exact-head repository validation + producer-distinct PRE_ADOPTION_REVIEW are required before merge.