### PR TITLE
fix(ci): report Engine Validate on every PR

### DIFF
--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -3,16 +3,6 @@ name: Engine Validate
 on:
   pull_request:
     branches: [main]
-    paths:
-      - package.json
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
-      - packages/engine/**
-      - schemas/**
-      - standard/catalog.yaml
-      - scripts/validate-workspace-packages.mjs
-      - scripts/check-public-boundary.mjs
-      - .github/workflows/engine.yml
   push:
     branches:
       - main


### PR DESCRIPTION
Closes #13

## Goal

Make the existing `Engine Validate` required-check context appear on every pull request targeting `main`, including changes outside the engine path set, without weakening the validation job itself.

## Change

Remove only the `pull_request.paths` filter from `.github/workflows/engine.yml`. The job steps, job/check name, `Validate` workflow, and push-path optimization remain unchanged.

## Safety / compatibility

- `Engine Validate` still runs the full core, workspace, and public-boundary validation when triggered.
- `Validate` is untouched.
- No branch-protection/ruleset, release, Scheduled Task, package, or Standard semantics are changed.
- Rollback is the inverse one-file workflow edit if the always-on PR check proves materially too costly.

## Candidate

Base/control: `main@e0c8555d8589ece0eaab4fb18c1bb6a23bb22b32`

Head: `5ccc6f99a5c352f3f1bedf8a7a953070714cc05a`

This branch was rebuilt directly onto the current trusted base after the prior candidate became stale. All earlier base/head review state is stale. Fresh exact-head validation and producer-distinct PRE_ADOPTION_REVIEW are required before merge.