### PR TITLE
fix(ci): report Engine Validate on every PR

### DIFF
--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -3,16 +3,6 @@ name: Engine Validate
 on:
   pull_request:
     branches: [main]
-    paths:
-      - package.json
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
-      - packages/engine/**
-      - schemas/**
-      - standard/catalog.yaml
-      - scripts/validate-workspace-packages.mjs
-      - scripts/check-public-boundary.mjs
-      - .github/workflows/engine.yml
   push:
     branches:
       - main


### PR DESCRIPTION
Closes #13

Recovery PR for the existing exact safe operand `codex/recover-pr-18-engine-validate-identity@ad54b40be9892eaa569ed081522c5a708307b70d`.

Current integration baseline: `main@45dd729316a9ba01d7afb1ab51aba5d81931a2a1` (tree `786092cec53000932465ca9a9b31565cbec742f1`) after PR #46 integration. The candidate head is unchanged and the scope remains exactly one workflow change: remove only the `pull_request.paths` filter from `.github/workflows/engine.yml` so `Engine Validate` reports on every PR targeting `main`, while retaining the existing validation job and push-path optimization.

Lifecycle: stale PR #18 is superseded/closed. Issue #23 is closed `not_planned` under the current USER public-Git-identity policy and is not an integration blocker.

Current gate: cached/native merge evidence predating current `main` is stale. SENTINEL independently reconstructed the current-base expected root tree as `5eabad092f89f998003ed3ddcc5d1fab5916462c` for `main@45dd7293... + ad54b40...`; this is deterministic operand identity only, not execution validation. GitHub's current synthetic merge `d371722f72903b81a4c39c6561e8d7d3570dae03` is stale because its first parent is `ac87df22f4b816e12451b8f9e2f83a0174e19eb2`, not current `main`.

Before integration, reuse canonical `WC-8` and the existing CODEX_LOCAL queue. CODEX_LOCAL must re-fetch then-current `main` and unchanged PR head `ad54b40be9892eaa569ed081522c5a708307b70d`; only if they remain exactly `45dd7293... + ad54b40...`, independently construct/check out the merged state and require root tree `5eabad092f89f998003ed3ddcc5d1fab5916462c`. Then run `pnpm validate:strict` plus Engine Validate-equivalent engine/workspace/public validation on that exact state. Any movement of `main` or the candidate head invalidates the operand and requires a fresh current-base reconstruction before integration.