### PR TITLE
chore: normalize project licensing to standard MIT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ NewChoBo Harness is developed publicly. Treat source files, commit messages, bra
 
 If information is not clearly safe for public disclosure, do not post it here. Use synthetic/minimized reproductions and keep private evidence in its authorized private source. The canonical rule is [`protocol/public-information-boundary`](standard/protocols/public-information-boundary.md).
 
+## Licensing of contributions
+
+By submitting a contribution to this repository, you agree that your contribution is provided under the project's MIT License. This does not transfer ownership of your original contribution; it establishes the license under which the contribution is accepted and redistributed as part of NewChoBo Harness.
+
 ## Change flow
 
 Material changes follow:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Newchobo and contributors
+Copyright (c) 2026 NewChoBo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,13 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-Additional Attribution Requirement
-
-When this package is used in a product or service, the following attribution
-must be included in visible notices such as README, About, or credits:
-
-`Powered by Newchobo`
-
-Including a link to the upstream source is recommended.
-


### PR DESCRIPTION
## Summary

- replace the custom MIT-derived license with the standard MIT License
- preserve the original project copyright notice as `Copyright (c) 2026 NewChoBo`
- remove the custom `Powered by Newchobo` visible-attribution requirement
- clarify that submitted contributions are accepted under the project's MIT License without transferring ownership of contributors' original work

## Intent

The project is permissively reusable: forks, modifications, private derivatives, redistribution, and commercial use remain allowed. The original MIT copyright and permission notice must remain with copies or substantial portions of the Software.

This deliberately does **not** prohibit forks from using a different project name or crediting their own modifications; it preserves the original NewChoBo copyright notice rather than imposing a copyleft or branding restriction.

## Validation

- `package.json` already declares `"license": "MIT"`, so the repository license text and package metadata are now aligned.
- no source/runtime behavior changed.