### PR TITLE
docs: add project slogan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NewChoBo Harness
 
+> 직접 일하기 귀찮은 모두를 위해
+
 NewChoBo Harness is a public, provider-neutral agent/workflow governance and control-plane system. It combines reusable semantic roles/protocols/checklists with a TypeScript reference engine, public workflow packages, repository-owned automation bindings, and exact-candidate review/adoption conventions.
 
 ## Source of truth

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@newchobo/harness",
   "private": false,
   "version": "0.1.0-alpha.0",
-  "description": "Reusable agent workflow harness core and public workflow overlays",
+  "description": "직접 일하기 귀찮은 모두를 위해 — reusable agent workflow harness core and public workflow overlays",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
## Summary

- add the project slogan `직접 일하기 귀찮은 모두를 위해` directly below the README title
- align the root package description with the same slogan

No runtime behavior or licensing semantics change.