### PR TITLE
docs: align consumer branding

### DIFF
--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -1,6 +1,6 @@
 # Consumer Boundaries
 
-Agent Harness is cross-domain. Shared artifacts define reusable workflow/governance semantics while each consumer keeps its own product, domain, repository, security, and operational policy local.
+NewChoBo Harness is cross-domain. Shared artifacts define reusable workflow/governance semantics while each consumer keeps its own product, domain, repository, security, and operational policy local.
 
 ## Consumer-owned policy
 
@@ -18,7 +18,7 @@ The shared Harness should reference only the abstract capability or contract nee
 
 ## Shared promotion rule
 
-A consumer rule may move into Agent Harness only when it can be described and validated without exposing consumer-specific names, confidential/domain facts, personal/sensitive information, private identifiers, credentials, or private evidence.
+A consumer rule may move into NewChoBo Harness only when it can be described and validated without exposing consumer-specific names, confidential/domain facts, personal/sensitive information, private identifiers, credentials, or private evidence.
 
 Private evidence may motivate a shared improvement, but the shared artifact records only the generalized finding and the minimum non-sensitive provenance needed for review.
 


### PR DESCRIPTION
## Summary
- replace the two product-identifying `Agent Harness` references in `docs/consumers.md` with `NewChoBo Harness`
- preserve generic/shared Harness wording and the stable `agent-harness` compatibility identifier

## Evidence
- exact reviewed head: `09c10e35969aec8841944fbecfff042096cab2c5`
- base: `main@e9735ab63bfa80cabdb5d3666e7592d5f0e190f2`
- diff: one file, `+2/-2`
- producer-distinct SENTINEL verdict: `PASS / EXACT_HEAD_DOCS_BRANDING_REVIEW`

This PR does not change behavior, APIs, workflows, catalog/schema, runtime semantics, or release/package configuration.