### PR TITLE
docs: clarify public boundary evidence scope

### DIFF
--- a/scripts/check-public-boundary.mjs
+++ b/scripts/check-public-boundary.mjs
@@ -67,4 +67,6 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
-console.log(`Public information boundary check passed for ${files.length} tracked files.`);
+console.log(
+  `Tracked-file public boundary check passed for ${files.length} tracked files; non-file public surfaces require separate evidence.`,
+);

--- a/standard/protocols/public-information-boundary.md
+++ b/standard/protocols/public-information-boundary.md
@@ -11,7 +11,7 @@ Assume anything written to a public surface can become immediately world-readabl
 Public surfaces include:
 
 - source, documentation, examples, fixtures, snapshots, generated outputs, and package metadata;
-- commit author metadata/messages and branch/tag names;
+- commit author/committer metadata/messages and branch/tag names;
 - Issues, Pull Requests, reviews, comments, labels, milestones, and public project metadata;
 - workflow logs, artifacts, summaries, releases, release assets, registries, and generated documentation.
 
@@ -22,10 +22,12 @@ If information is not clearly safe for public disclosure, do not write it public
 Use only the distinction needed for persistence:
 
 - `PUBLIC_SAFE` — intentionally public and reusable.
-- `NON_PUBLIC` — secrets, personal/sensitive data, private consumer/project/customer/domain information, private coordinates, private evidence, internal state, or unpublished material.
+- `NON_PUBLIC` — secrets, personal/sensitive data not explicitly authorized for public disclosure, private consumer/project/customer/domain information, private coordinates, private evidence, internal state, or unpublished material.
 - `UNKNOWN` — current evidence cannot establish public safety.
 
 `UNKNOWN` is fail-closed and is treated like `NON_PUBLIC` for persistence. This is a write gate, not a general data-classification language.
+
+Disclosure status is contextual and evidence-backed. Repository-owner Git author/committer metadata may be `PUBLIC_SAFE` when the owner explicitly authorizes that exact identity for public repositories. That authorization does not generalize to third-party identities, other personal data, secrets, private material, or unknown identifiers, and must not be inferred merely because an identity already appears in public history.
 
 Do not commit confidential denylists or inventories of private identities to enforce this protocol. Private environments may run additional local checks that never become public artifacts.
 
@@ -105,4 +107,14 @@ Use layered validation:
 - public secret/static/path checks;
 - private local checks for confidential identifiers that must not be committed.
 
-A scanner is defense in depth. A green scanner does not prove public safety.
+### Automated tracked-file scope
+
+`scripts/check-public-boundary.mjs` checks the current tracked repository file paths and readable file payloads returned by `git ls-files`. It detects only the filename, path, LFS-pointer, and text-pattern classes implemented by that script.
+
+The tracked-file check does **not** inspect or attest commit/ref metadata, Issues/PRs/reviews/comments/project metadata, workflow logs/artifacts, releases/assets, registries, caches/forks/mirrors, or host/account state. Those public surfaces require surface-appropriate evidence, for example:
+
+- raw Git/GitHub metadata inspection for commit/ref identity and provenance when material;
+- exact host API/UI, workflow, release, registry, or artifact evidence plus review for collaboration and publication surfaces;
+- private/host-local checks for confidential identifier sets or sensitive detection inputs that must not be committed publicly.
+
+A green tracked-file scanner means only that its implemented tracked-file checks passed. It is defense in depth, not whole-surface disclosure proof.

--- a/test/public-boundary.test.ts
+++ b/test/public-boundary.test.ts
@@ -39,7 +39,8 @@ describe('public information boundary script', () => {
     const result = runBoundaryCheck({ 'README.md': '# Public example\n' });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Public information boundary check passed');
+    expect(result.stdout).toContain('Tracked-file public boundary check passed');
+    expect(result.stdout).toContain('non-file public surfaces require separate evidence');
   });
 
   it('fails closed when a tracked Git LFS pointer is not hydrated', () => {


### PR DESCRIPTION
## Summary

Reconcile the existing public-information-boundary owner without creating a second policy surface.

- make `scripts/check-public-boundary.mjs` explicitly a tracked-file/path/payload check rather than whole-surface disclosure proof;
- keep non-file public surfaces on surface-appropriate raw metadata / host / workflow / release / registry evidence and review;
- reflect that repository-owner Git author/committer metadata may be `PUBLIC_SAFE` only when that exact identity has explicit public-disclosure authorization;
- keep unauthorized third-party/personal/private/secret/unknown identifiers fail-closed and avoid public identity denylists;
- keep the boundary script regression test aligned with the new scope-explicit success message.

Canonical owner remains #1 and `standard/protocols/public-information-boundary.md`. This does not replace or weaken the #32 Agent Security Boundary or #35 repository/supply-chain hardening work.

## Frozen successor candidate

- base: `main@ff4e14d1d3975130a50bc28c58a5bd7476703cf1`
- head: `139ae153ed605d31be3b40aa6dbc7760ca793e02`
- tree: `c5a2fc0a57c1a8065e7bbde6b38c04d679b95208`
- delta: 3 files, +20/-5

The first head `95106776...` failed `Validate #269` only because `test/public-boundary.test.ts` still expected the old success string. The successor updates that test and adds an assertion for the new non-file-evidence warning.

Raw author and committer metadata for both producer commits were re-fetched after creation and match the repository's current owner-authorized public identity policy. No history rewrite, tag/release mutation, or scheduler change was performed.

## Exact-head validation

For successor `139ae153...`:

- `Validate #270` — SUCCESS
- `Engine Validate #77` — SUCCESS

Prior-head check results are retained only as historical evidence and are not used as successor PASS.

## Review gate

No adoption/integration is requested from the producer. Fresh exact-head producer-distinct SENTINEL review is pending for `139ae153...`. Repository CI/check evidence is candidate validation only; a green tracked-file scan does not prove non-file public surfaces are safe.