### PR TITLE
fix(research): clarify overlay role composition

### DIFF
--- a/packages/harness-workflow-research/research-overlay.md
+++ b/packages/harness-workflow-research/research-overlay.md
@@ -31,7 +31,8 @@ current decision / assumption / recurring failure
 ```
 
 The canonical result vocabulary and silent no-delta behavior are defined by
-`role/researcher`; this overlay composes that behavior rather than replacing it.
+`role/researcher`. This overlay reuses that vocabulary as research guidance; selecting
+this overlay does not by itself select or require `role/researcher` as the effective role.
 Before inventing a reusable abstraction, proportionally inspect mature products,
 standards/protocols, current official documentation, strong open-source
 implementations, primary research, and credible production evidence that could


### PR DESCRIPTION
Post-integration regression follow-up for the delivered Issue #19 / PR #29 acceptance lineage.

Exact base at construction: `main@d5fdb39c9ae172223afb17a080a424d24dea6167`
Exact candidate: `3bc2b14d11a36af9b4063a4bd5a2d2198e58832e`

The merged research overlay said it `composes` behavior defined by `role/researcher`, but `packages/harness-workflow-research/preset.yaml` has neither `role` nor `extends`, and the preset contract does not define a protocol-to-specific-role dependency. PR #29's intent and the package README support vocabulary/provenance alignment rather than an implicit effective-role guarantee.

This is deliberately wording-only: the overlay continues to reuse the canonical Researcher result vocabulary while stating that selecting the overlay does not itself select or require `role/researcher` as the effective role. No schema/DSL, role binding, authority, catalog identity, or runtime behavior is added.

Do not merge/adopt on producer mutation alone. Require exact-head validation and fresh producer-distinct SENTINEL review on the frozen candidate before governor adoption.