### PR TITLE
docs(coding): fix shared semantics owner reference

### DIFF
--- a/packages/harness-workflow-coding/coding-overlay.md
+++ b/packages/harness-workflow-coding/coding-overlay.md
@@ -3,7 +3,7 @@
 ## Intent
 
 - Keep repository-specific implementation policy local.
-- Preserve shared control semantics from `@newchobo/harness-core`.
+- Preserve shared control semantics from `@newchobo/harness`.
 
 ## Recommended defaults
 


### PR DESCRIPTION
## Summary

Correct the coding workflow overlay's shared-semantics owner reference from `@newchobo/harness-core` to `@newchobo/harness`.

## Why

- `packages/harness-workflow-coding/package.json` depends on `@newchobo/harness`, not `@newchobo/harness-core`.
- `packages/engine/README.md` explicitly states that shared governance semantics are canonical in the public Standard resources shipped by `@newchobo/harness`.
- This is a documentation/consumer-guidance repair only; it does not change package/runtime composition or introduce a cross-package dependency DSL.

## Scope

One file, one line. The research and novel sibling overlays were rechecked; no broader source change is included here.

## Validation

Exact-head repository validation is required before producer-distinct review/adoption.