### PR TITLE
fix(ci): exclude active PR bases from branch cleanup debt

### DIFF
--- a/.github/workflows/branch-maintenance.yml
+++ b/.github/workflows/branch-maintenance.yml
@@ -53,6 +53,7 @@ jobs:
                 .filter((pull) => pull.head.repo?.full_name === `${owner}/${repo}`)
                 .map((pull) => pull.head.ref),
             );
+            const comparisonsByHead = new Map();
             const cleanupDebt = [];
 
             for (const branch of branches) {
@@ -63,23 +64,32 @@ jobs:
                 continue;
               }
 
-              const comparison = await github.request(
-                'GET /repos/{owner}/{repo}/compare/{basehead}',
-                {
-                  owner,
-                  repo,
-                  basehead: `${defaultBranch}...${branch.name}`,
-                },
-              );
+              let comparison = comparisonsByHead.get(branch.commit.sha);
+              if (!comparison) {
+                const response = await github.request(
+                  'GET /repos/{owner}/{repo}/compare/{basehead}',
+                  {
+                    owner,
+                    repo,
+                    basehead: `${defaultBranch}...${branch.commit.sha}`,
+                  },
+                );
+                comparison = response.data;
+                comparisonsByHead.set(branch.commit.sha, comparison);
+              } else {
+                core.info(
+                  `Reusing ${defaultBranch}...${branch.commit.sha} comparison for ${branch.name}`,
+                );
+              }
 
-              if (comparison.data.ahead_by === 0) {
+              if (comparison.ahead_by === 0) {
                 cleanupDebt.push({
                   branch: branch.name,
                   head: branch.commit.sha,
                 });
               } else {
                 core.info(
-                  `Keeping ${branch.name}: ${comparison.data.ahead_by} commit(s) are not in ${defaultBranch}`,
+                  `Keeping ${branch.name}: ${comparison.ahead_by} commit(s) are not in ${defaultBranch}`,
                 );
               }
             }

--- a/.github/workflows/branch-maintenance.yml
+++ b/.github/workflows/branch-maintenance.yml
@@ -53,11 +53,21 @@ jobs:
                 .filter((pull) => pull.head.repo?.full_name === `${owner}/${repo}`)
                 .map((pull) => pull.head.ref),
             );
+            const activeBases = new Set(
+              openPulls
+                .filter((pull) => pull.base.repo?.full_name === `${owner}/${repo}`)
+                .map((pull) => pull.base.ref),
+            );
             const comparisonsByHead = new Map();
             const cleanupDebt = [];
 
             for (const branch of branches) {
-              if (branch.name === defaultBranch || branch.protected || activeHeads.has(branch.name)) {
+              if (
+                branch.name === defaultBranch ||
+                branch.protected ||
+                activeHeads.has(branch.name) ||
+                activeBases.has(branch.name)
+              ) {
                 continue;
               }
               if (!shortLivedPrefixes.some((prefix) => branch.name.startsWith(prefix))) {

--- a/test/branch-maintenance.test.ts
+++ b/test/branch-maintenance.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync('.github/workflows/branch-maintenance.yml', 'utf8');
+
+describe('branch lifecycle audit', () => {
+  it('excludes branches used by an open PR as either head or base', () => {
+    expect(workflow).toContain('const activeHeads = new Set(');
+    expect(workflow).toContain('const activeBases = new Set(');
+    expect(workflow).toContain('.map((pull) => pull.head.ref)');
+    expect(workflow).toContain('.map((pull) => pull.base.ref)');
+    expect(workflow).toContain('activeHeads.has(branch.name)');
+    expect(workflow).toContain('activeBases.has(branch.name)');
+  });
+
+  it('applies per-branch lifecycle gates before exact-head comparison reuse', () => {
+    const headGate = workflow.indexOf('activeHeads.has(branch.name)');
+    const baseGate = workflow.indexOf('activeBases.has(branch.name)');
+    const prefixGate = workflow.indexOf('shortLivedPrefixes.some');
+    const cacheLookup = workflow.indexOf('comparisonsByHead.get(branch.commit.sha)');
+
+    expect(headGate).toBeGreaterThan(-1);
+    expect(baseGate).toBeGreaterThan(headGate);
+    expect(prefixGate).toBeGreaterThan(baseGate);
+    expect(cacheLookup).toBeGreaterThan(prefixGate);
+  });
+
+  it('binds compare evidence to the exact observed branch head SHA', () => {
+    expect(workflow).toContain('const comparisonsByHead = new Map()');
+    expect(workflow).toContain('basehead: `${defaultBranch}...${branch.commit.sha}`');
+    expect(workflow).toContain('comparisonsByHead.set(branch.commit.sha, comparison)');
+  });
+});


### PR DESCRIPTION
## Summary

Repairs a concrete false-positive in the read-only Branch Lifecycle Audit and keeps the exact-head compare de-dup as a secondary optimization.

### Correctness repair

The workflow previously tracked only open PR **head** refs while its summary claimed cleanup candidates “have no open PR.” A short-lived branch that is fully contained in `main` but is the **base** of an open PR could therefore be incorrectly reported as `BRANCH_CLEANUP_ADMIN_REQUIRED`.

This successor now:
- builds both `activeHeads` and `activeBases` from same-repository open PRs;
- excludes a branch used in either role before any ancestry comparison;
- adds `test/branch-maintenance.test.ts` regression coverage for head/base exclusion and gate ordering.

### Exact-head evidence reuse

After all per-branch gates (`default`, `protected`, open PR head/base, short-lived prefix) pass, the audit binds ancestry evidence to the exact `listBranches` head SHA already observed and reuses one `defaultBranch...headSha` compare per unique SHA. This avoids both duplicate compare requests and inventory-vs-compare head drift without treating shared SHA as deletion authority.

## Safety boundary

This remains a read-only audit. It adds no ref deletion, automatic cleanup, alias-reduction semantics, force update, or new lifecycle verdict. Branch-name-specific workflow/consumer behavior remains independent evidence. The current five `f36e65c...` historical refs remain retained under the existing Issue #24 semantic-validation gate.

## Successor candidate

- base: `45dd729316a9ba01d7afb1ab51aba5d81931a2a1`
- head: `cf8c8e4ca04da2c96c9d96a9247f891002b500b7`
- changed surfaces: `.github/workflows/branch-maintenance.yml`, `test/branch-maintenance.test.ts`
- prior head `b7782f75335758ea1273cc15e0195f85e4dea029` is superseded and must not be reviewed/adopted.

Draft pending successor exact-head validation and fresh producer-distinct SENTINEL review. No merge/adoption/release authority is implied.